### PR TITLE
docs: enable twitter preview

### DIFF
--- a/content/index.smd
+++ b/content/index.smd
@@ -1,5 +1,5 @@
 ---
-.title = "Welcome",
+.title = "Welcome to ZML",
 .layout = "index.shtml",
 .author = "renerocksai",
 .date = @date("2024-08-30"),

--- a/layouts/templates/base.shtml
+++ b/layouts/templates/base.shtml
@@ -2,12 +2,13 @@
 <html>
   <head id="head">
     <meta charset="UTF-8">
-    <!-- <meta name="description" content="Zine: Fast, Scalable and Flexible Static Site Generator"> -->
-    <!-- <meta name="twitter:card" content="summary"> -->
-    <!-- <meta name="twitter:site" content="@zml.ai"> -->
-    <!-- <meta name="twitter:author" content="@zml.ai"> -->
-    <!-- <meta name="twitter:description" content="Zine: Fast, Scalable and Flexible Static Site Generator"> -->
-    <!-- <meta name="twitter:title" content="$page.title.suffix(' | ZML')"> -->
+    <meta name="description" content="ZML - A high performance AI inference stack. Built for production. @ziglang / @openxla / MLIR / @bazelbuild">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@zml_ai">
+    <meta name="twitter:author" content="@zml_ai">
+    <meta name="twitter:description" content="ZML - A high performance AI inference stack. Built for production. @ziglang / @openxla / MLIR / @bazelbuild">
+    <meta name="twitter:image" content="https://zml.ai/zml_nolight.svg">
+    <meta name="twitter:title" content="$page.title.suffix(' | ZML')">
     <meta property="og:title" content="$page.title">
     <meta property="og:type" content="website">
     <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
Un-commented and fixed the twitter card and other meta info. WhatsApp was using the commented-out ones that contained outdated information, linking to Zine.