### PR TITLE
fix: remove horizontal scroll caused by menu overflow

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -71,7 +71,7 @@ body {
   padding: 0;
 
   display: grid;
-  grid-template-columns: 250px auto;
+  grid-template-columns: 250px minmax(0, 1fr);
   grid-template-rows: auto 1fr;
   grid-template-areas: "logo menu"
                             "side content"
@@ -85,7 +85,6 @@ body {
   padding: 7px 20px 7px 0px;
 /*  border-top: 1px solid #27b8f3;*/
 /*  border-bottom: 1px solid #27b8f3;*/
-  width: 100%;
   margin-top: 2px;
   height: 1.5em;
   text-align: center;
@@ -396,7 +395,7 @@ li {
 
   /* When the sidebar and logo are shown (burger menu active) */
   body.show-sidebar {
-    grid-template-columns: 250px auto; /* Two columns: sidebar + content */
+    grid-template-columns: 250px minmax(0, 1fr);
     grid-template-areas:
       "logo menu"
       "side content"


### PR DESCRIPTION
## Summary

- Replace `auto` with `minmax(0, 1fr)` in grid-template-columns to prevent the menu column from growing beyond available viewport space
- Remove `width: 100%` on `#menu` which, combined with `content-box` sizing and 20px right padding, caused the element to overflow its grid cell by 20px (amplified to ~26px at zoom 1.3)